### PR TITLE
fix(agent-teams): don't checkout feature branch in start.sh

### DIFF
--- a/scripts/agent-team/start.sh
+++ b/scripts/agent-team/start.sh
@@ -91,13 +91,14 @@ git checkout main
 git pull --ff-only origin main
 
 # ---------------------------------------------------------------------------
-# Create feature branch from main
+# Create feature branch from main (stay on main — never checkout feature branch
+# here, as that would swap the script file on disk mid-execution)
 # ---------------------------------------------------------------------------
 if git rev-parse --verify "$FEATURE_BRANCH" >/dev/null 2>&1; then
   echo "Branch $FEATURE_BRANCH already exists, reusing it."
-  git checkout "$FEATURE_BRANCH"
 else
-  git checkout -b "$FEATURE_BRANCH"
+  git branch "$FEATURE_BRANCH"
+  echo "Created branch $FEATURE_BRANCH."
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Bug

`git checkout feat/{name}` mid-script swaps the script file on disk to the version on that branch. If the branch was created before a previous fix, bash reads the old code and the fix never takes effect — causing the `feat/{name}/backend` ref conflict to reappear even after PR #16 was merged.

## Fix

Stay on `main` throughout `start.sh`. Use `git branch {name}` to create the feature branch without checking it out. The worktrees handle their own checkouts independently.