### PR TITLE
feat(copilot): add Copilot CLI agentic workflow

### DIFF
--- a/.github/agents/backend-dev.agent.md
+++ b/.github/agents/backend-dev.agent.md
@@ -1,0 +1,50 @@
+# Backend Developer Agent
+
+You are a senior .NET backend developer implementing features for the Chairly platform using Vertical Slice Architecture.
+
+## How you work
+
+1. Read the spec at the path provided in your prompt
+2. Extract your assigned backend tasks from the YAML frontmatter
+3. Implement each task in dependency order
+4. Run quality checks after completing all tasks
+5. Commit your work with conventional commits
+
+## Implementation order
+
+For each task, follow this order:
+1. Domain entities and value objects (`Chairly.Domain/Entities/`)
+2. EF Core configurations (`Chairly.Infrastructure/Persistence/Configurations/`)
+3. Register DbSet in `ChairlyDbContext`
+4. Create and verify migration
+5. Command/Query + Handler + Endpoint in `Chairly.Api/Features/{Context}/{UseCase}/`
+6. Register endpoint group in `Program.cs`
+7. Unit tests in `Chairly.Tests/Features/{Context}/`
+
+## Key patterns
+
+- Read existing slices in `Chairly.Api/Features/` before implementing new ones
+- Use the `/backend-entity`, `/backend-handler`, `/backend-endpoint`, `/backend-ef-config`, and `/backend-test` skills for boilerplate patterns
+- Use OneOf for result types with failure cases
+- Use Data Annotations for input validation
+- Append `.ConfigureAwait(false)` to every `await`
+- Wrap DI-instantiated `internal sealed class` with `#pragma warning disable CA1812`
+
+## Working in worktrees
+
+You may be working in a git worktree at `.worktrees/{feature}/backend/`.
+All file paths are relative to the worktree root. Run migrations from the worktree:
+```bash
+dotnet ef migrations add {Name} --project src/backend/Chairly.Infrastructure --startup-project src/backend/Chairly.Api
+```
+
+## Quality checks
+
+Run before committing:
+```bash
+dotnet build src/backend/Chairly.slnx
+dotnet test src/backend/Chairly.slnx
+dotnet format src/backend/Chairly.slnx --verify-no-changes
+```
+
+Fix format issues with `dotnet format src/backend/Chairly.slnx`, then verify again.

--- a/.github/agents/frontend-dev.agent.md
+++ b/.github/agents/frontend-dev.agent.md
@@ -1,0 +1,54 @@
+# Frontend Developer Agent
+
+You are a senior Angular developer implementing features for the Chairly platform using Nx monorepo with DDD layers.
+
+## How you work
+
+1. Read the spec at the path provided in your prompt
+2. Extract your assigned frontend tasks from the YAML frontmatter
+3. Implement each task in dependency order
+4. Run quality checks after completing all tasks
+5. Commit your work with conventional commits
+
+## Implementation order
+
+For each task, follow this order:
+1. Models/interfaces in `libs/chairly/src/lib/{domain}/models/`
+2. API service in `libs/chairly/src/lib/{domain}/data-access/`
+3. NgRx SignalStore in `libs/chairly/src/lib/{domain}/data-access/`
+4. Presentational (dumb) components in `libs/chairly/src/lib/{domain}/ui/{component-name}/`
+5. Smart (container) components in `libs/chairly/src/lib/{domain}/feature/{feature-name}/`
+6. Routes at `libs/chairly/src/lib/{domain}/{domain}.routes.ts`
+7. Register route in app router
+8. Barrel exports (`index.ts`) in each layer folder
+9. Unit tests (`.spec.ts`) for components
+10. E2E tests in `apps/chairly-e2e/src/`
+
+## Key patterns
+
+- Read existing domains in `libs/chairly/src/lib/` before implementing new ones
+- Use the `/frontend-store`, `/frontend-service`, `/frontend-component`, `/frontend-routing`, and `/frontend-test` skills for boilerplate patterns
+- All UI text in Dutch (Nederlands)
+- Standalone components with OnPush change detection
+- Signal-based APIs: `input()`, `model()`, `viewChild()`, `OutputEmitterRef`
+- Always use `templateUrl:` with separate `.html` file
+- Pair every light-mode color with a `dark:` Tailwind variant
+- Use `takeUntilDestroyed(destroyRef)` for subscriptions
+
+## Working in worktrees
+
+You may be working in a git worktree at `.worktrees/{feature}/frontend/`.
+All file paths are relative to the worktree root.
+
+## Quality checks
+
+Run before committing:
+```bash
+cd src/frontend/chairly
+npx nx affected -t lint --base=main
+npx nx format:check --base=main
+npx nx affected -t test --base=main
+npx nx affected -t build --base=main
+```
+
+Fix format issues with `npx nx format --base=main`, then verify again.

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -1,0 +1,59 @@
+# Code Reviewer Agent
+
+You are a senior code reviewer for the Chairly platform. You review implementations against the spec and project conventions, auto-fix what you can, and report what needs human judgment.
+
+## How you work
+
+1. Read the spec at the path provided in your prompt
+2. Read all files changed since the feature branch diverged from main:
+   ```bash
+   git diff main...HEAD --name-only
+   ```
+3. Review each changed file against the checklist below
+4. **Auto-fix** issues you can resolve with confidence (formatting, missing dark mode variants, missing `.ConfigureAwait(false)`, incorrect file placement)
+5. **Report** issues that need human judgment in `.github/tasks/{feature-name}/review.md`
+6. Run quality checks after fixes
+7. Commit fixes with `fix({feature}): address review findings`
+
+## Review checklist — Backend
+
+- [ ] Slice structure follows `Features/{Context}/{UseCase}/` pattern
+- [ ] Handlers contain all business logic (none in endpoints)
+- [ ] OneOf used for result types with failure cases
+- [ ] Data Annotations on command/query properties
+- [ ] `.ConfigureAwait(false)` on every `await`
+- [ ] `#pragma warning disable CA1812` on DI-instantiated classes
+- [ ] Timestamps used instead of status columns (ADR-009)
+- [ ] `TenantId` on all entities
+- [ ] Migrations are idempotent (`IF NOT EXISTS`)
+- [ ] Unit tests cover happy path, validation, and not-found cases
+
+## Review checklist — Frontend
+
+- [ ] Files in correct DDD layer folders (models/, data-access/, feature/, ui/)
+- [ ] Sheriff module boundaries respected (no cross-domain imports)
+- [ ] OnPush change detection on all components
+- [ ] Signal-based APIs used (no `@Input/@Output/@ViewChild`)
+- [ ] `templateUrl:` with separate `.html` file (no inline template)
+- [ ] All UI text in Dutch
+- [ ] Dark mode: every light-mode color paired with `dark:` variant
+- [ ] `takeUntilDestroyed(destroyRef)` for subscriptions
+- [ ] No `any` types, no `console` statements
+- [ ] No function calls in templates
+- [ ] E2E tests in `apps/chairly-e2e/src/`
+
+## Report format (review.md)
+
+```markdown
+# Review Findings — {feature-name}
+
+## Auto-fixed
+- {description of fix} ({file path})
+
+## Needs human judgment
+- {description of issue} ({file path}:{line})
+  **Options:** {option A} vs {option B}
+
+## All clear
+- {areas that passed review with no issues}
+```

--- a/.github/agents/rework.agent.md
+++ b/.github/agents/rework.agent.md
@@ -1,0 +1,49 @@
+# Rework Agent
+
+You are a senior developer fixing PR review comments for the Chairly platform. You read PR comments, apply targeted fixes, and push the changes.
+
+## How you work
+
+1. Fetch PR comments for the given PR number:
+   ```bash
+   gh pr view {PR_NUMBER} --json reviews,comments --jq '.reviews[].body, .comments[].body'
+   gh api repos/{owner}/{repo}/pulls/{PR_NUMBER}/comments --jq '.[].body'
+   ```
+2. Read the spec at `.github/tasks/{feature-name}/spec.md` for context
+3. Categorize each comment as backend, frontend, or both
+4. Fix each comment in the appropriate location
+5. Run quality checks for affected layers
+6. Commit and push fixes
+
+## Rules
+
+- Only fix what the reviewer asked for — do not gold-plate or refactor beyond the comments
+- If a comment is ambiguous, implement the most conservative interpretation
+- Use conventional commits: `fix({feature}): address PR review comments`
+
+## Git workflow
+
+You work on the existing feature branch. If worktrees exist, use them:
+- Backend: `.worktrees/{feature}/backend/` on `impl/{feature}-backend` branch
+- Frontend: `.worktrees/{feature}/frontend/` on `impl/{feature}-frontend` branch
+
+After fixing:
+```bash
+# In each worktree with changes
+git add -A
+git commit -m "fix({feature}): address PR review comments ({layer})"
+git push
+
+# Merge worktree branches into feature branch
+git checkout feat/{feature}
+git merge --no-ff impl/{feature}-backend -m "chore: merge backend rework fixes"
+git merge --no-ff impl/{feature}-frontend -m "chore: merge frontend rework fixes"
+git push origin feat/{feature}
+```
+
+## After fixing
+
+Post a summary comment on the PR:
+```bash
+gh pr comment {PR_NUMBER} --body "Rework complete. Addressed {N} comments. Changes pushed to feat/{feature}."
+```

--- a/.github/agents/spec-writer.agent.md
+++ b/.github/agents/spec-writer.agent.md
@@ -1,0 +1,53 @@
+# Spec Writer Agent
+
+You are a senior software architect who creates detailed feature specifications for the Chairly platform. You work interactively with the developer to produce a complete, implementable spec.
+
+## Input sources
+
+You accept input in three forms:
+
+1. **Free-form prompt** — a feature description typed directly
+2. **GitHub issue** — when the input is an issue number (e.g. `#42` or `42`) or issue URL, fetch it:
+   ```bash
+   gh issue view {number} --json title,body,labels,assignees
+   ```
+   Use the issue title, body, and labels as the feature description. Preserve the issue link in the spec summary for traceability.
+3. **File path** — read the file contents as the feature description
+
+## How you work
+
+1. Determine the input source (prompt, issue, or file) and read the feature description
+2. Read `docs/domain-model.md` to understand existing entities and relationships
+3. Read `docs/adr/` for relevant architecture decisions
+4. Read existing specs in `.github/tasks/` for format reference
+5. **Ask clarifying questions** before writing — never assume technical choices. Present 2-3 options with trade-offs when decisions are needed.
+6. Produce the spec at `.github/tasks/{feature-name}/spec.md`
+
+## Spec output format
+
+The spec must follow the format defined in `.github/instructions/workflow.instructions.md`:
+- YAML frontmatter with tasks, dependencies, and status fields
+- Markdown body with: Summary, User Stories, Acceptance Criteria, Domain Model Changes, API Contracts, UI/UX Description, Test Requirements, Out of Scope
+
+## Task breakdown rules
+
+- Each task should be one logical unit of work (one entity, one handler, one component)
+- Backend tasks (`B{n}`) come before frontend tasks (`F{n}`) in dependency order
+- Mark cross-layer dependencies explicitly in `depends_on`
+- Include test tasks for each layer
+
+## Questions to always ask
+
+- What user roles need access to this feature?
+- Are there any existing entities or endpoints that should be reused?
+- What validation rules apply?
+- Are there edge cases or error states to handle?
+- What should be explicitly out of scope?
+
+## Spec update mode
+
+When asked to update an existing spec based on feedback:
+1. Read the current spec at the provided path
+2. Apply the requested changes
+3. Preserve all sections not mentioned in the feedback
+4. Update task statuses if tasks were added or removed

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,67 @@
+# Chairly — Copilot Instructions
+
+## Project
+
+Chairly is a multi-tenant SaaS platform for salons and barbershops.
+
+## Tech Stack
+
+- **Backend:** .NET 10, ASP.NET Core Web API, EF Core, OneOf (result pattern)
+- **Frontend:** Angular 21, Nx monorepo, NgRx SignalStore, Tailwind CSS v4, SCSS, Sheriff
+- **Testing:** xUnit (backend), Vitest (frontend unit), Playwright (frontend e2e)
+- **Infra:** PostgreSQL (database-per-tenant), RabbitMQ, Keycloak, .NET Aspire, Docker
+
+## Architecture Overview
+
+- **Backend:** Vertical Slice Architecture (VSA) with thin shared layers. See `docs/adr/` for architecture decisions.
+- **Frontend:** Nx monorepo with DDD layers enforced by Sheriff. See `.github/instructions/frontend.instructions.md` for details.
+- **Domain model:** See `docs/domain-model.md` for entities, relationships, and ubiquitous language.
+
+## Ubiquitous Language
+
+- **Booking** (never "appointment") — a scheduled visit with one or more services
+- **Client** (never "customer") — a person who receives services
+- **Staff Member** (never "employee") — a person who works at the salon
+- **Service** — a catalog offering (e.g. "Men's Haircut")
+- **Tenant** — a single salon location
+
+See `docs/domain-model.md` for the complete glossary.
+
+## User Roles
+
+- **Owner** — full admin, one per tenant
+- **Manager** — manages staff and schedules, no billing/settings access
+- **Staff Member** — sees and manages own schedule only
+
+## Commit Conventions
+
+Use conventional commits: `feat(bookings): add create booking endpoint`
+
+Prefixes: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`
+
+## Implementation Order
+
+1. Domain entities and value objects
+2. EF Core configuration and migration
+3. Handlers with validation
+4. API endpoints
+5. Angular feature (service -> store -> components -> routes)
+6. Tests at every step
+
+## Forbidden
+
+- No `any` types in TypeScript
+- No `console` statements in production code
+- No business logic in controllers/endpoints
+- No direct use of DbContext outside Infrastructure layer
+- No hardcoded strings for configuration
+- No status enum columns — use timestamp pairs (ADR-009)
+- No cross-domain imports in the frontend without going through `shared/`
+- No MediatR NuGet package — use the custom mediator
+- No `@Input()`/`@Output()`/`@ViewChild()` decorators — use signal-based APIs
+- No `Subject` + `ngOnDestroy` — use `takeUntilDestroyed(destroyRef)`
+- No function calls in Angular templates — use signals or pipes
+- No inline styles or inline `template:` in Angular components
+- No English user-facing text in the UI — all UI copy must be in Dutch (Nederlands)
+- No raw ID inputs in user-facing forms — use searchable dropdowns or selection lists
+- Never commit without tests passing

--- a/.github/docs/copilot-workflow.md
+++ b/.github/docs/copilot-workflow.md
@@ -1,0 +1,212 @@
+# Copilot CLI Agentic Workflow
+
+This document describes how to use the Copilot CLI agentic workflow to create specifications, implement features, review code, create pull requests, and do rework based on PR comments.
+
+## Prerequisites
+
+- [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli) installed and authenticated
+- `gh` CLI authenticated with repo access
+- .NET 10 SDK and Node.js 20+ installed
+- Repository cloned locally
+
+## Workflow Overview
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────────┐
+│  1. Spec      │────▶│  2. Review   │────▶│  3. Implement    │
+│  (interactive)│     │  (human)     │     │  (autopilot)     │
+└──────────────┘     └──────┬───────┘     └────────┬─────────┘
+                            │                      │
+                     ┌──────▼───────┐     ┌────────▼─────────┐
+                     │  2a. Update  │     │  4. Review PR    │
+                     │  spec        │     │  (human)         │
+                     └──────────────┘     └────────┬─────────┘
+                                                   │
+                                          ┌────────▼─────────┐
+                                          │  4a. Rework      │
+                                          │  (agent)         │
+                                          └──────────────────┘
+```
+
+## Step 1 — Create a Specification
+
+Start an interactive session with the spec-writer agent:
+
+```bash
+copilot --agent=spec-writer
+```
+
+The agent will:
+- Ask clarifying questions about your feature
+- Present options when decisions are needed
+- Produce a spec at `.github/tasks/{feature-name}/spec.md`
+
+The spec contains:
+- **YAML frontmatter** — machine-readable tasks, dependencies, and status tracking
+- **Markdown body** — human-readable narrative with user stories, API contracts, UI descriptions
+
+### From a prompt
+
+```bash
+copilot --agent=spec-writer --prompt "I want to add a booking management feature where staff members can create, view, and cancel bookings for clients."
+```
+
+### From a GitHub issue
+
+```bash
+copilot --agent=spec-writer --prompt "Create a spec from issue #42"
+```
+
+The agent fetches the issue title, body, and labels via `gh issue view` and uses them as the feature description. The issue link is preserved in the spec for traceability.
+
+## Step 2 — Review the Specification
+
+Open `.github/tasks/{feature-name}/spec.md` and review:
+- Are all user stories captured?
+- Are the API contracts correct?
+- Is the task breakdown reasonable?
+- Is anything missing from scope?
+
+### Step 2a — Update the Spec
+
+If you have comments, invoke the spec-writer again:
+
+```bash
+copilot --agent=spec-writer --prompt "Update the spec at .github/tasks/booking-management/spec.md: add a user story for recurring bookings and mark the notification integration as out of scope"
+```
+
+## Step 3 — Implement the Feature
+
+Once the spec is approved, kick off implementation in autopilot mode:
+
+```bash
+copilot --autopilot --yolo --max-autopilot-continues 30 -p "/fleet Implement the feature spec at .github/tasks/{feature-name}/spec.md. Use the backend-dev agent for all backend tasks and the frontend-dev agent for all frontend tasks. Set up git worktrees: .worktrees/{feature-name}/backend/ on branch impl/{feature-name}-backend and .worktrees/{feature-name}/frontend/ on branch impl/{feature-name}-frontend, both branching from feat/{feature-name}. After implementation, use the reviewer agent to review the code. Then merge worktree branches into feat/{feature-name} and create a PR to main."
+```
+
+### What happens
+
+1. **Git setup** — Creates `feat/{feature-name}` branch and two worktrees
+2. **`/fleet` parallelization** — Delegates backend tasks to `backend-dev` agent and frontend tasks to `frontend-dev` agent, running in parallel
+3. **Quality checks** — Each agent runs build/test/lint before committing
+4. **Review** — The `reviewer` agent checks the implementation, auto-fixes issues, and writes remaining findings to `review.md`
+5. **PR creation** — Merges worktree branches and creates a pull request
+
+### Git branch structure
+
+```
+main
+ └── feat/{feature-name}              ← PR target
+      ├── impl/{feature-name}-backend      ← backend worktree
+      └── impl/{feature-name}-frontend     ← frontend worktree
+```
+
+## Step 4 — Review the Pull Request
+
+Review the PR on GitHub as usual. Leave inline comments and review summaries.
+
+### Step 4a — Rework Based on PR Comments
+
+After leaving comments, invoke the rework agent:
+
+```bash
+copilot --agent=rework --prompt "Fix the review comments on PR #42"
+```
+
+The rework agent will:
+1. Fetch all PR comments via `gh api`
+2. Categorize comments as backend, frontend, or both
+3. Apply targeted fixes in the appropriate worktree
+4. Run quality checks
+5. Commit, push, and post a summary comment on the PR
+
+For a fully autonomous rework pass:
+
+```bash
+copilot --autopilot --yolo --agent=rework --prompt "Fix the review comments on PR #42"
+```
+
+## Agents Reference
+
+| Agent | File | Purpose | Mode |
+|---|---|---|---|
+| `spec-writer` | `.github/agents/spec-writer.agent.md` | Create/update feature specs | Interactive |
+| `backend-dev` | `.github/agents/backend-dev.agent.md` | Implement backend tasks | Autopilot |
+| `frontend-dev` | `.github/agents/frontend-dev.agent.md` | Implement frontend tasks | Autopilot |
+| `reviewer` | `.github/agents/reviewer.agent.md` | Review code, auto-fix, report | Autopilot |
+| `rework` | `.github/agents/rework.agent.md` | Fix PR review comments | Either |
+
+## Skills Reference
+
+Skills are automatically loaded by Copilot when relevant to the current task.
+
+| Skill | Folder | Loaded when... |
+|---|---|---|
+| `backend-entity` | `.github/skills/backend-entity/` | Creating domain entities |
+| `backend-handler` | `.github/skills/backend-handler/` | Implementing handlers |
+| `backend-endpoint` | `.github/skills/backend-endpoint/` | Wiring API endpoints |
+| `backend-ef-config` | `.github/skills/backend-ef-config/` | Database configuration/migrations |
+| `backend-test` | `.github/skills/backend-test/` | Writing backend tests |
+| `frontend-store` | `.github/skills/frontend-store/` | Creating NgRx SignalStores |
+| `frontend-service` | `.github/skills/frontend-service/` | Creating API services |
+| `frontend-component` | `.github/skills/frontend-component/` | Building Angular components |
+| `frontend-routing` | `.github/skills/frontend-routing/` | Setting up routes |
+| `frontend-test` | `.github/skills/frontend-test/` | Writing frontend tests |
+
+## Quality Hooks
+
+A pre-commit hook (`.github/hooks/copilot-hooks.json`) automatically runs quality checks before any `git commit`:
+
+- **Backend:** `dotnet build`, `dotnet test`, `dotnet format --verify-no-changes`
+- **Frontend:** `npx nx affected -t lint test build`, `npx nx format:check`
+
+The hook only runs checks for the layer that has staged changes. If checks fail, the commit is blocked.
+
+## File Structure
+
+```
+.github/
+├── copilot-instructions.md              # Base project rules (always loaded)
+├── instructions/
+│   ├── backend.instructions.md          # Backend conventions (src/backend/**)
+│   ├── frontend.instructions.md         # Frontend conventions (src/frontend/**)
+│   ├── testing.instructions.md          # Test patterns (*.test.*, *.spec.*)
+│   └── workflow.instructions.md         # Spec format (.github/tasks/**)
+├── agents/
+│   ├── spec-writer.agent.md             # Spec creation agent
+│   ├── backend-dev.agent.md             # Backend implementation agent
+│   ├── frontend-dev.agent.md            # Frontend implementation agent
+│   ├── reviewer.agent.md                # Code review agent
+│   └── rework.agent.md                  # PR rework agent
+├── skills/
+│   ├── backend-entity/SKILL.md          # Domain entity patterns
+│   ├── backend-handler/SKILL.md         # Handler patterns
+│   ├── backend-endpoint/SKILL.md        # Endpoint patterns
+│   ├── backend-ef-config/SKILL.md       # EF Core config patterns
+│   ├── backend-test/SKILL.md            # Backend test patterns
+│   ├── frontend-store/SKILL.md          # NgRx SignalStore patterns
+│   ├── frontend-service/SKILL.md        # API service patterns
+│   ├── frontend-component/SKILL.md      # Component patterns
+│   ├── frontend-routing/SKILL.md        # Route patterns
+│   └── frontend-test/SKILL.md           # Frontend test patterns
+├── hooks/
+│   └── copilot-hooks.json               # Pre-commit quality gate
+├── tasks/
+│   └── {feature-name}/
+│       ├── spec.md                      # Feature specification
+│       └── review.md                    # Review findings (generated)
+└── docs/
+    └── copilot-workflow.md              # This file
+```
+
+## Tips
+
+- **Adjust `--max-autopilot-continues`** based on feature size. Small features: 10-15. Large features: 30-50.
+- **Check `/skills list`** to see which skills Copilot has loaded.
+- **Use `/agent`** in interactive mode to switch between agents mid-session.
+- **Review `review.md`** after implementation to see what the reviewer found and couldn't auto-fix.
+- If `/fleet` doesn't delegate to custom agents as expected, fall back to sequential invocation:
+  ```bash
+  copilot --autopilot --yolo --agent=backend-dev --prompt "Implement backend tasks from .github/tasks/{feature}/spec.md in worktree .worktrees/{feature}/backend/"
+  copilot --autopilot --yolo --agent=frontend-dev --prompt "Implement frontend tasks from .github/tasks/{feature}/spec.md in worktree .worktrees/{feature}/frontend/"
+  copilot --autopilot --yolo --agent=reviewer --prompt "Review the implementation for feature {feature}"
+  ```

--- a/.github/hooks/copilot-hooks.json
+++ b/.github/hooks/copilot-hooks.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "./scripts/copilot/pre-commit-check.sh",
+        "cwd": ".",
+        "timeoutSec": 120
+      }
+    ]
+  }
+}

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -1,0 +1,71 @@
+---
+applyTo: "src/backend/**"
+---
+
+# Backend Conventions — Vertical Slice Architecture
+
+## Projects
+
+- `Chairly.Domain` — Entities, value objects, enums. No use-case logic. No EF Core dependency.
+- `Chairly.Infrastructure` — DbContext, EF configurations, RabbitMQ, Keycloak integration.
+- `Chairly.Api` — Vertical slices organized by feature. Contains the custom mediator.
+- `Chairly.AppHost` — .NET Aspire orchestrator for local development.
+- `Chairly.ServiceDefaults` — Shared Aspire configuration.
+- `Chairly.Tests` — Unit and integration tests.
+
+## Slice Structure
+
+```
+Chairly.Api/Features/{Context}/{UseCase}/
+  ├── {UseCase}Command.cs or {UseCase}Query.cs
+  ├── {UseCase}Handler.cs
+  ├── {UseCase}Endpoint.cs
+  └── {UseCase}Validator.cs
+```
+
+## Rules
+
+- Each slice contains everything for one use case: command/query, handler, validator, endpoint
+- Slices in the same bounded context may reference each other
+- Slices across bounded contexts must NOT reference each other — use domain events or shared contracts
+- Business logic lives in handlers, NEVER in endpoints
+
+## Custom Mediator (ADR-005)
+
+Custom mediator (no MediatR package). Located in `Chairly.Api/Shared/Mediator/`.
+Interfaces: `IRequest<TResponse>`, `IRequestHandler<TRequest, TResponse>`, `IMediator`, `IPipelineBehavior<TRequest, TResponse>`
+
+## Naming
+
+- Commands: `Create{Entity}Command`, `Update{Entity}Command`, `Delete{Entity}Command`
+- Queries: `Get{Entity}Query`, `Get{Entities}ListQuery`
+- Handlers: `{CommandOrQuery}Handler`
+- Validators: `{CommandOrQuery}Validator`
+- Endpoints: `{CommandOrQuery}Endpoint`
+
+## Patterns
+
+- Use OneOf for the result pattern (no exceptions for business logic)
+- Data Annotations + manual validation for input validation
+- Entity configurations in separate `IEntityTypeConfiguration<T>` classes
+- All endpoints via Minimal APIs, grouped per feature in extension methods
+- Timestamps instead of status columns (ADR-009): `{Action}AtUtc` + `{Action}By` pairs
+- `CreatedAtUtc`/`CreatedBy` required on all entities
+- Database-per-tenant: all entities carry `TenantId`, tenant resolution via middleware
+- EF Core migrations must be idempotent (use `IF NOT EXISTS` patterns)
+- Append `.ConfigureAwait(false)` to every `await` expression
+
+## Async patterns in Program.cs
+
+- Avoid `await using` — use try/finally with `await scope.DisposeAsync().ConfigureAwait(false)` (CA2007/MA0004)
+- Use `await app.RunAsync().ConfigureAwait(false)` instead of `app.Run()` (CA1849)
+
+## Quality Checks
+
+```bash
+dotnet build src/backend/Chairly.slnx
+dotnet test src/backend/Chairly.slnx
+dotnet format src/backend/Chairly.slnx --verify-no-changes
+```
+
+If `dotnet format` fails, auto-fix with `dotnet format src/backend/Chairly.slnx` then verify again.

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -1,0 +1,108 @@
+---
+applyTo: "src/frontend/**"
+---
+
+# Frontend Conventions — Nx Monorepo with DDD & Sheriff
+
+## Workspace
+
+`src/frontend/chairly/` — Nx monorepo with apps/libs layout.
+
+## Structure
+
+```
+src/frontend/chairly/
+├── apps/
+│   ├── chairly/              # Main Angular application
+│   └── chairly-e2e/          # Playwright e2e tests
+├── libs/
+│   ├── chairly/src/lib/      # Domain library
+│   │   ├── bookings/         # Each domain has the layers below
+│   │   ├── clients/          #   feature/{feature-name}/ — smart components
+│   │   ├── staff/            #   ui/ — presentational components
+│   │   ├── services/         #   data-access/ — stores, API services
+│   │   ├── billing/          #   models/ — TypeScript interfaces/types
+│   │   └── notifications/    #   pipes/, util/, {domain}.routes.ts
+│   └── shared/src/lib/       # Shared library (ui/, data-access/, util/)
+```
+
+## Path Aliases
+
+`@org/chairly-lib`, `@org/shared-lib`
+
+## Module Boundary Rules (Sheriff)
+
+- A domain cannot import from another domain
+- A domain can import from `shared/`
+- `shared/` cannot import from any domain
+- Within a domain: `feature/` -> `ui/`, `data-access/`, `models/`, `pipes/`, `util/`
+- `ui/` -> `models/`, `pipes/`, `util/` only
+- `data-access/` -> `models/`, `util/` only
+
+## File Placement
+
+| File type | Correct folder |
+|---|---|
+| TypeScript interfaces/DTOs | `models/` |
+| Angular `@Pipe` classes | `pipes/` |
+| Pure TS utility functions | `util/` |
+| Smart (container) components | `feature/{feature-name}/` subfolder |
+| Presentational components | `ui/{component-name}/` subfolder |
+| Route configuration | `{domain}.routes.ts` at domain root |
+
+## Code Conventions
+
+- Standalone components, no NgModules
+- OnPush change detection on all components
+- Signal-based APIs: `input()`, `model()`, `viewChild()`, `OutputEmitterRef`
+- NgRx SignalStore for shared/feature state
+- `takeUntilDestroyed(destroyRef)` for subscription cleanup (always inject `DestroyRef` explicitly)
+- Smart/Dumb component pattern
+- Tailwind CSS v4 for styling, SCSS for component styles
+- Reactive forms with typed FormGroups
+- Lazy-loaded routes per domain
+- Component prefix: `chairly-`
+- Always use `templateUrl:` with a separate `.html` file (no inline `template:`)
+- Omit `imports: []` when component has no imports
+- Self-closing tags for empty elements
+- Explicit return types on all functions
+- No `any` types, no `console` statements
+
+## UI Language — Dutch (Nederlands)
+
+All user-facing text must be Dutch from the first keystroke.
+Common translations: Save->Opslaan, Cancel->Annuleren, Add->Toevoegen, Edit->Bewerken,
+Delete->Verwijderen, Active->Actief, Inactive->Inactief, Loading->Laden, Confirm->Bevestigen
+
+## Locale Configuration
+
+In `app.config.ts`: `registerLocaleData(localeNl)`, provide `LOCALE_ID: 'nl-NL'` and `DEFAULT_CURRENCY_CODE: 'EUR'`.
+
+## Dark Mode
+
+`data-theme="dark"` on `<html>` (managed by `ThemeService`).
+Always pair light-mode background colors with a `dark:` Tailwind variant.
+Custom/brand colors (`bg-primary-*`, `bg-accent-*`) have no global dark override — always add explicit `dark:` variant.
+
+## Native `<dialog>` Pattern
+
+Use `showModal()` with full-screen overlay. Inject `DOCUMENT`, toggle `body.style.overflow`.
+Close via `page.keyboard.press('Escape')` in e2e tests.
+
+## Styles Setup
+
+- `apps/chairly/src/tailwind.css` — `@import 'tailwindcss'` + `@source` directives (plain CSS, never SCSS)
+- `apps/chairly/src/styles.scss` — SCSS globals (variables, mixins, fonts). Never merge with tailwind.css.
+- `postcss.config.json` is used by Angular builder (not `.mjs`)
+
+## Quality Checks
+
+```bash
+cd src/frontend/chairly
+npx nx affected -t lint --base=main
+npx nx format:check --base=main
+npx nx affected -t test --base=main
+npx nx affected -t build --base=main
+```
+
+If `npx nx format:check` fails, auto-fix with `npx nx format --base=main` then verify again.

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,56 @@
+---
+applyTo: "**/*.test.*,**/*.spec.*,**/Tests/**,**/*-e2e/**"
+---
+
+# Testing Conventions
+
+## Backend — xUnit
+
+- Unit tests for all handlers in `Chairly.Tests/Features/{Context}/{Entity}HandlerTests.cs`
+- Use in-memory database: `new DbContextOptionsBuilder<ChairlyDbContext>().UseInMemoryDatabase(Guid.NewGuid().ToString())`
+- Test happy path, validation failures, and not-found cases
+- Use `Validator.TryValidateObject()` for Data Annotation validation tests
+- Append `.ConfigureAwait(false)` to all `await` expressions
+
+### Test pattern
+
+```csharp
+[Fact]
+public async Task HandlerName_Scenario_ExpectedResult()
+{
+    await using var db = CreateDbContext();
+    var handler = new SomeHandler(db);
+    var command = new SomeCommand { /* ... */ };
+
+    var result = await handler.Handle(command);
+
+    Assert.Equal(expected, result.Property);
+}
+```
+
+## Frontend — Vitest (unit)
+
+- Component specs in `{component-name}.component.spec.ts` alongside the component
+- Use Angular testing utilities with Vitest
+- Test signal inputs, store interactions, and template rendering
+
+## Frontend — Playwright (e2e)
+
+- E2E tests in `apps/chairly-e2e/src/`
+- Write e2e tests for all pages/features
+- Use `page.keyboard.press('Escape')` to close `showModal()` dialogs (cross-browser reliable)
+- All test assertions against Dutch UI text
+
+## Running Tests
+
+Backend:
+```bash
+dotnet test src/backend/Chairly.slnx
+```
+
+Frontend:
+```bash
+cd src/frontend/chairly
+npx nx affected -t test --base=main
+npx nx affected -t e2e --base=main
+```

--- a/.github/instructions/workflow.instructions.md
+++ b/.github/instructions/workflow.instructions.md
@@ -1,0 +1,54 @@
+---
+applyTo: ".github/tasks/**"
+---
+
+# Spec & Task Workflow Conventions
+
+## Spec File Location
+
+All feature specs live in `.github/tasks/{feature-name}/spec.md`.
+
+## Spec Format
+
+Specs use YAML frontmatter for machine-readable task metadata and Markdown body for human-readable narrative.
+
+### Frontmatter fields
+
+```yaml
+---
+feature: {feature-name}
+status: draft | approved | in-progress | complete
+branches:
+  feature: feat/{feature-name}
+  backend: impl/{feature-name}-backend
+  frontend: impl/{feature-name}-frontend
+tasks:
+  - id: B1
+    title: {task title}
+    layer: backend
+    status: pending | in-progress | done
+    depends_on: []
+  - id: F1
+    title: {task title}
+    layer: frontend
+    status: pending | in-progress | done
+    depends_on: [B1]
+---
+```
+
+### Task ID conventions
+
+- `B{n}` — backend tasks
+- `F{n}` — frontend tasks
+- `R{n}` — review/rework tasks
+
+### Markdown body sections
+
+1. **Summary** — one-paragraph feature description
+2. **User Stories** — as a {role}, I want {goal}, so that {benefit}
+3. **Acceptance Criteria** — checklist per story
+4. **Domain Model Changes** — new entities, value objects, relationships
+5. **API Contracts** — endpoint definitions with request/response shapes
+6. **UI/UX Description** — component layout, user flows
+7. **Test Requirements** — what needs unit/integration/e2e tests
+8. **Out of Scope** — explicitly excluded items

--- a/.github/skills/backend-ef-config/SKILL.md
+++ b/.github/skills/backend-ef-config/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: backend-ef-config
+description: >
+  EF Core entity configuration and migration patterns for Chairly backend.
+  Use when creating database configurations, DbSet registrations, or migrations.
+---
+
+# EF Core Configuration Pattern
+
+Location: `Chairly.Infrastructure/Persistence/Configurations/{Entity}Configuration.cs`
+
+```csharp
+using Chairly.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+#pragma warning disable CA1812 // Instantiated via ApplyConfigurationsFromAssembly
+namespace Chairly.Infrastructure.Persistence.Configurations;
+
+internal sealed class {Entity}Configuration : IEntityTypeConfiguration<{Entity}>
+{
+    public void Configure(EntityTypeBuilder<{Entity}> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.HasKey(x => x.Id);
+        builder.Property(x => x.TenantId).IsRequired();
+        builder.Property(x => x.Name).IsRequired().HasMaxLength(150);
+        builder.Property(x => x.CreatedBy).IsRequired();
+        builder.Property(x => x.UpdatedBy).IsRequired(false);
+
+        // Indexes and relationships:
+        // builder.HasIndex(x => new { x.Name, x.TenantId }).IsUnique();
+        // builder.HasOne(x => x.Parent).WithMany().HasForeignKey(x => x.ParentId)
+        //     .IsRequired(false).OnDelete(DeleteBehavior.SetNull);
+    }
+}
+#pragma warning restore CA1812
+```
+
+After adding the configuration, register a `DbSet<{Entity}>` property in `ChairlyDbContext`.
+
+## Migration
+
+Run from inside the worktree or project root:
+
+```bash
+dotnet ef migrations add {MigrationName} \
+  --project src/backend/Chairly.Infrastructure \
+  --startup-project src/backend/Chairly.Api
+```
+
+## Idempotent migration rules
+
+All migrations MUST be idempotent:
+- `CreateTable` → use raw SQL: `CREATE TABLE IF NOT EXISTS`
+- `CreateIndex` → use: `CREATE INDEX IF NOT EXISTS`
+- `AddColumn` → wrap in `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'T' AND column_name = 'C') THEN ALTER TABLE "T" ADD COLUMN "C" ...; END IF; END $$;`
+
+Never use bare `migrationBuilder.CreateTable()`, `migrationBuilder.CreateIndex()`, or `migrationBuilder.AddColumn()`.

--- a/.github/skills/backend-endpoint/SKILL.md
+++ b/.github/skills/backend-endpoint/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: backend-endpoint
+description: >
+  Minimal API endpoint patterns for Chairly backend.
+  Use when wiring up API endpoints in VSA slices.
+---
+
+# Endpoint Patterns
+
+## POST (returns 201 Created)
+
+```csharp
+using Chairly.Api.Shared.Mediator;
+
+namespace Chairly.Api.Features.{Context}.{UseCase};
+
+internal static class {UseCase}Endpoint
+{
+    public static void Map{UseCase}(this RouteGroupBuilder group)
+    {
+        group.MapPost("/", async (
+            {UseCase}Command command,
+            IMediator mediator,
+            CancellationToken cancellationToken) =>
+        {
+            var result = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+            return Results.Created($"/api/{context}/{result.Id}", result);
+        });
+    }
+}
+```
+
+## PUT/PATCH with OneOf (200 OK or 404)
+
+```csharp
+group.MapPut("/{id:guid}", async (
+    Guid id,
+    {UseCase}Command command,
+    IMediator mediator,
+    CancellationToken cancellationToken) =>
+{
+    command.Id = id;
+    var result = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+    return result.Match(
+        entity => Results.Ok(entity),
+        _ => Results.NotFound());
+});
+```
+
+## DELETE with OneOf (204 No Content or 404)
+
+```csharp
+group.MapDelete("/{id:guid}", async (
+    Guid id,
+    IMediator mediator,
+    CancellationToken cancellationToken) =>
+{
+    var result = await mediator.Send(new {UseCase}Command(id), cancellationToken).ConfigureAwait(false);
+    return result.Match(
+        _ => Results.NoContent(),
+        _ => Results.NotFound());
+});
+```
+
+## GET list (200 OK)
+
+```csharp
+group.MapGet("/", async (
+    IMediator mediator,
+    CancellationToken cancellationToken) =>
+{
+    var result = await mediator.Send(new Get{Entities}ListQuery(), cancellationToken).ConfigureAwait(false);
+    return Results.Ok(result);
+});
+```
+
+## Endpoint group file
+
+Location: `Chairly.Api/Features/{Context}/{Context}Endpoints.cs`
+
+```csharp
+namespace Chairly.Api.Features.{Context};
+
+internal static class {Context}Endpoints
+{
+    public static IEndpointRouteBuilder Map{Context}Endpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/{context}");
+
+        group.Map{UseCase1}();
+        group.Map{UseCase2}();
+
+        return app;
+    }
+}
+```
+
+Register in `Program.cs`: `app.Map{Context}Endpoints();`

--- a/.github/skills/backend-entity/SKILL.md
+++ b/.github/skills/backend-entity/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: backend-entity
+description: >
+  Domain entity and value object patterns for Chairly backend.
+  Use when creating new entities in Chairly.Domain/Entities/.
+---
+
+# Domain Entity Pattern
+
+Location: `Chairly.Domain/Entities/{Entity}.cs`
+
+```csharp
+namespace Chairly.Domain.Entities;
+
+public class {Entity}
+{
+    public Guid Id { get; set; }
+    public Guid TenantId { get; set; }
+
+    // domain properties here
+
+    public DateTimeOffset CreatedAtUtc { get; set; }
+    public Guid CreatedBy { get; set; }
+    public DateTimeOffset? UpdatedAtUtc { get; set; }
+    public Guid? UpdatedBy { get; set; }
+}
+```
+
+## Rules
+
+- No EF Core dependency in Domain project
+- Navigation properties are allowed (e.g. `public ServiceCategory? Category { get; set; }`)
+- Status is never stored — derive it from timestamp pairs (`CancelledAtUtc` means cancelled)
+- `CreatedAtUtc`/`CreatedBy` required on all entities
+- All entities carry `TenantId`
+
+## Response Record
+
+Location: `Chairly.Api/Features/{Context}/{Entity}Response.cs` (shared across slices in same context)
+
+```csharp
+namespace Chairly.Api.Features.{Context};
+
+internal sealed record {Entity}Response(
+    Guid Id,
+    string Name,
+    // other properties
+    DateTimeOffset CreatedAtUtc,
+    Guid CreatedBy,
+    DateTimeOffset? UpdatedAtUtc,
+    Guid? UpdatedBy);
+```

--- a/.github/skills/backend-handler/SKILL.md
+++ b/.github/skills/backend-handler/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: backend-handler
+description: >
+  Handler implementation patterns for Chairly backend using custom mediator and OneOf.
+  Use when implementing command/query handlers in VSA slices.
+---
+
+# Handler Patterns
+
+## Command (write operation)
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Chairly.Api.Shared.Mediator;
+
+#pragma warning disable CA1812
+namespace Chairly.Api.Features.{Context}.{UseCase};
+
+internal sealed class {UseCase}Command : IRequest<{Response}>
+{
+    [Required]
+    [MaxLength(150)]
+    public string Name { get; set; } = string.Empty;
+}
+#pragma warning restore CA1812
+```
+
+## Query (read operation)
+
+```csharp
+using Chairly.Api.Shared.Mediator;
+using OneOf;
+using OneOf.Types;
+
+namespace Chairly.Api.Features.{Context}.{UseCase};
+
+internal sealed record {UseCase}Query(Guid Id) : IRequest<OneOf<{Response}, NotFound>>;
+```
+
+## Handler — simple return (no failure case)
+
+```csharp
+using Chairly.Api.Shared.Mediator;
+using Chairly.Api.Shared.Tenancy;
+using Chairly.Domain.Entities;
+using Chairly.Infrastructure.Persistence;
+
+#pragma warning disable CA1812
+namespace Chairly.Api.Features.{Context}.{UseCase};
+
+internal sealed class {UseCase}Handler(ChairlyDbContext db) : IRequestHandler<{UseCase}Command, {Response}>
+{
+    public async Task<{Response}> Handle({UseCase}Command command, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var entity = new {Entity}
+        {
+            Id = Guid.NewGuid(),
+            TenantId = TenantConstants.DefaultTenantId,
+            Name = command.Name,
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+#pragma warning disable MA0026
+            CreatedBy = Guid.Empty,
+#pragma warning restore MA0026
+        };
+
+        db.{Entities}.Add(entity);
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return ToResponse(entity);
+    }
+
+    private static {Response} ToResponse({Entity} entity) =>
+        new(entity.Id, entity.Name, entity.CreatedAtUtc, entity.CreatedBy, entity.UpdatedAtUtc, entity.UpdatedBy);
+}
+#pragma warning restore CA1812
+```
+
+## Handler — OneOf return (failure cases)
+
+```csharp
+using Chairly.Api.Shared.Mediator;
+using Chairly.Api.Shared.Tenancy;
+using Chairly.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using OneOf;
+using OneOf.Types;
+
+#pragma warning disable CA1812
+namespace Chairly.Api.Features.{Context}.{UseCase};
+
+internal sealed class {UseCase}Handler(ChairlyDbContext db) : IRequestHandler<{UseCase}Command, OneOf<{Response}, NotFound>>
+{
+    public async Task<OneOf<{Response}, NotFound>> Handle({UseCase}Command command, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var entity = await db.{Entities}
+            .FirstOrDefaultAsync(x => x.Id == command.Id && x.TenantId == TenantConstants.DefaultTenantId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            return new NotFound();
+        }
+
+        // apply changes
+        entity.UpdatedAtUtc = DateTimeOffset.UtcNow;
+#pragma warning disable MA0026
+        entity.UpdatedBy = Guid.Empty;
+#pragma warning restore MA0026
+
+        await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return ToResponse(entity);
+    }
+
+    private static {Response} ToResponse({Entity} entity) =>
+        new(entity.Id, entity.Name, entity.CreatedAtUtc, entity.CreatedBy, entity.UpdatedAtUtc, entity.UpdatedBy);
+}
+#pragma warning restore CA1812
+```
+
+## Pragma reference
+
+| Pragma | When |
+|---|---|
+| `#pragma warning disable CA1812` | Every `internal sealed class` instantiated via DI |
+| `#pragma warning disable MA0026` | Every `CreatedBy = Guid.Empty` / `UpdatedBy = Guid.Empty` |
+| `.ConfigureAwait(false)` | Every `await` expression |

--- a/.github/skills/backend-test/SKILL.md
+++ b/.github/skills/backend-test/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: backend-test
+description: >
+  xUnit test patterns for Chairly backend handlers.
+  Use when writing unit tests for command/query handlers.
+---
+
+# Backend Test Patterns
+
+Location: `Chairly.Tests/Features/{Context}/{Entity}HandlerTests.cs`
+
+```csharp
+using System.ComponentModel.DataAnnotations;
+using Chairly.Api.Features.{Context}.Create{Entity};
+using Chairly.Api.Features.{Context}.Update{Entity};
+using Chairly.Api.Shared.Tenancy;
+using Chairly.Domain.Entities;
+using Chairly.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using OneOf.Types;
+
+namespace Chairly.Tests.Features.{Context};
+
+public class {Entity}HandlerTests
+{
+    private static ChairlyDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<ChairlyDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        return new ChairlyDbContext(options);
+    }
+
+    private static {Entity} CreateTest{Entity}(ChairlyDbContext db)
+    {
+        var entity = new {Entity}
+        {
+            Id = Guid.NewGuid(),
+            TenantId = TenantConstants.DefaultTenantId,
+            Name = "Test {Entity}",
+            CreatedAtUtc = DateTimeOffset.UtcNow,
+        };
+        db.{Entities}.Add(entity);
+        db.SaveChanges();
+        return entity;
+    }
+
+    [Fact]
+    public async Task Create{Entity}Handler_HappyPath_Creates{Entity}()
+    {
+        await using var db = CreateDbContext();
+        var handler = new Create{Entity}Handler(db);
+        var command = new Create{Entity}Command { Name = "Test Name" };
+
+        var result = await handler.Handle(command);
+
+        Assert.NotEqual(Guid.Empty, result.Id);
+        Assert.Equal("Test Name", result.Name);
+        Assert.Equal(1, await db.{Entities}.CountAsync());
+    }
+
+    [Fact]
+    public void Create{Entity}Command_EmptyName_FailsValidation()
+    {
+        var command = new Create{Entity}Command { Name = string.Empty };
+        var results = new List<ValidationResult>();
+        var context = new ValidationContext(command);
+
+        var isValid = Validator.TryValidateObject(command, context, results, validateAllProperties: true);
+
+        Assert.False(isValid);
+        Assert.Contains(results, r => r.MemberNames.Contains(nameof(Create{Entity}Command.Name), StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task Update{Entity}Handler_NotFound_ReturnsNotFound()
+    {
+        await using var db = CreateDbContext();
+        var handler = new Update{Entity}Handler(db);
+
+        var result = await handler.Handle(new Update{Entity}Command { Id = Guid.NewGuid(), Name = "Any" });
+
+        Assert.True(result.IsT1);
+        Assert.IsType<NotFound>(result.AsT1);
+    }
+}
+```
+
+## Test naming convention
+
+`{MethodName}_{Scenario}_{ExpectedResult}`
+
+## What to test
+
+- Happy path for every handler
+- Validation failures (Data Annotations)
+- Not-found cases (OneOf returns `NotFound`)
+- Edge cases specific to business logic

--- a/.github/skills/frontend-component/SKILL.md
+++ b/.github/skills/frontend-component/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: frontend-component
+description: >
+  Angular component patterns for Chairly frontend (smart and presentational).
+  Use when creating new components with signals, OnPush, and templateUrl.
+---
+
+# Component Patterns
+
+## Smart (container) component
+
+Location: `libs/chairly/src/lib/{domain}/feature/{feature-name}/{feature-name}.component.ts`
+
+```typescript
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit } from '@angular/core';
+
+import { {Entity}Store } from '../../data-access';
+
+@Component({
+  selector: 'chairly-{feature-name}',
+  templateUrl: './{feature-name}.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class {FeatureName}Component implements OnInit {
+  private readonly store = inject({Entity}Store);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly items = this.store.items;
+  readonly loading = this.store.loading;
+
+  ngOnInit(): void {
+    this.store.loadAll();
+  }
+}
+```
+
+## Presentational (dumb) component
+
+Location: `libs/chairly/src/lib/{domain}/ui/{component-name}/{component-name}.component.ts`
+
+```typescript
+import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
+
+import { {Entity}Response } from '../../models';
+
+@Component({
+  selector: 'chairly-{component-name}',
+  templateUrl: './{component-name}.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class {ComponentName}Component {
+  readonly items = input.required<{Entity}Response[]>();
+  readonly itemSelected = output<{Entity}Response>();
+}
+```
+
+## Rules
+
+- Always use `templateUrl:` with a separate `.html` file (no inline template)
+- Always use `ChangeDetectionStrategy.OnPush`
+- Standalone components (no NgModules)
+- Signal-based APIs: `input()`, `model()`, `viewChild()`, `output()`
+- Omit `imports: []` when component has no imports
+- Prefix: `chairly-`
+- All UI text in Dutch
+- Pair every light-mode color with `dark:` Tailwind variant
+- Every presentational component in its own `ui/{component-name}/` subfolder
+- Use `takeUntilDestroyed(destroyRef)` for subscriptions (inject `DestroyRef` explicitly)
+
+## Native `<dialog>` pattern
+
+```html
+<dialog
+  class="fixed inset-0 m-0 w-screen h-screen max-w-none max-h-none flex items-center justify-center border-0 bg-black/50 p-4"
+>
+  <div class="bg-white dark:bg-slate-800 rounded-lg shadow-xl w-full max-w-md mx-auto">
+    <!-- content -->
+  </div>
+</dialog>
+```
+
+Inject `DOCUMENT`, toggle `document.body.style.overflow` on open/close.

--- a/.github/skills/frontend-routing/SKILL.md
+++ b/.github/skills/frontend-routing/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: frontend-routing
+description: >
+  Route configuration patterns for Chairly frontend domains.
+  Use when setting up lazy-loaded routes and domain route files.
+---
+
+# Routing Patterns
+
+## Domain routes file
+
+Location: `libs/chairly/src/lib/{domain}/{domain}.routes.ts` (at domain root, NOT inside feature/)
+
+```typescript
+import { Route } from '@angular/router';
+
+import { {Entity}ApiService, {Entity}Store } from './data-access';
+import { {Entity}ListPageComponent } from './feature';
+
+export const {domain}Routes: Route[] = [
+  {
+    path: '',
+    component: {Entity}ListPageComponent,
+    providers: [{Entity}Store, {Entity}ApiService],
+  },
+];
+```
+
+## Register in app router
+
+In `apps/chairly/src/app/app.routes.ts`:
+
+```typescript
+export const appRoutes: Route[] = [
+  {
+    path: '{domain}',
+    loadChildren: () =>
+      import('@org/chairly-lib').then((m) => m.{domain}Routes),
+  },
+];
+```
+
+## Rules
+
+- Routes file lives at domain root, not inside `feature/`
+- Lazy-loaded routes per domain
+- Store and API service provided at route level
+- Each route component gets its own `feature/{feature-name}/` subfolder
+
+## Feature barrel export
+
+Location: `libs/chairly/src/lib/{domain}/feature/index.ts`
+
+```typescript
+export { {Entity}ListPageComponent } from './{entity}-list-page/{entity}-list-page.component';
+```

--- a/.github/skills/frontend-service/SKILL.md
+++ b/.github/skills/frontend-service/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: frontend-service
+description: >
+  API service patterns for Chairly frontend using HttpClient.
+  Use when creating services that call backend endpoints.
+---
+
+# API Service Pattern
+
+Location: `libs/chairly/src/lib/{domain}/data-access/{entity}-api.service.ts`
+
+```typescript
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { API_BASE_URL } from '@org/shared-lib';
+
+import {
+  {Entity}Response,
+  Create{Entity}Request,
+  Update{Entity}Request,
+} from '../models';
+
+@Injectable()
+export class {Entity}ApiService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = inject(API_BASE_URL);
+
+  getAll(): Observable<{Entity}Response[]> {
+    return this.http.get<{Entity}Response[]>(`${this.baseUrl}/api/{context}`);
+  }
+
+  getById(id: string): Observable<{Entity}Response> {
+    return this.http.get<{Entity}Response>(`${this.baseUrl}/api/{context}/${id}`);
+  }
+
+  create(request: Create{Entity}Request): Observable<{Entity}Response> {
+    return this.http.post<{Entity}Response>(`${this.baseUrl}/api/{context}`, request);
+  }
+
+  update(id: string, request: Update{Entity}Request): Observable<{Entity}Response> {
+    return this.http.put<{Entity}Response>(`${this.baseUrl}/api/{context}/${id}`, request);
+  }
+
+  delete(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/api/{context}/${id}`);
+  }
+}
+```
+
+## Rules
+
+- One service per backend context
+- Injectable at route level (not `providedIn: 'root'`)
+- Use `API_BASE_URL` injection token from shared lib
+- Explicit return types on all methods
+- One method per HTTP verb/endpoint

--- a/.github/skills/frontend-store/SKILL.md
+++ b/.github/skills/frontend-store/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: frontend-store
+description: >
+  NgRx SignalStore patterns for Chairly frontend.
+  Use when creating or modifying state management stores.
+---
+
+# NgRx SignalStore Pattern
+
+Location: `libs/chairly/src/lib/{domain}/data-access/{entity}.store.ts`
+
+```typescript
+import { computed, inject } from '@angular/core';
+import {
+  patchState,
+  signalStore,
+  withComputed,
+  withMethods,
+  withState,
+} from '@ngrx/signals';
+import { rxMethod } from '@ngrx/signals/rxjs-interop';
+import { tapResponse } from '@ngrx/operators';
+import { pipe, switchMap, tap } from 'rxjs';
+
+import { {Entity}Response } from '../models';
+import { {Entity}ApiService } from './{entity}-api.service';
+
+export interface {Entity}State {
+  items: {Entity}Response[];
+  loading: boolean;
+  error: string | null;
+}
+
+const initialState: {Entity}State = {
+  items: [],
+  loading: false,
+  error: null,
+};
+
+export const {Entity}Store = signalStore(
+  withState(initialState),
+  withComputed((store) => ({
+    hasItems: computed(() => store.items().length > 0),
+  })),
+  withMethods((store, api = inject({Entity}ApiService)) => ({
+    loadAll: rxMethod<void>(
+      pipe(
+        tap(() => patchState(store, { loading: true, error: null })),
+        switchMap(() =>
+          api.getAll().pipe(
+            tapResponse({
+              next: (items) => patchState(store, { items, loading: false }),
+              error: (err: Error) =>
+                patchState(store, { error: err.message, loading: false }),
+            }),
+          ),
+        ),
+      ),
+    ),
+  })),
+);
+```
+
+## Barrel export (`data-access/index.ts`)
+
+```typescript
+export type { {Entity}State } from './{entity}.store';
+export { {Entity}Store } from './{entity}.store';
+export { {Entity}ApiService } from './{entity}-api.service';
+```
+
+## Rules
+
+- Store is provided at route level, not root
+- Use `rxMethod` for async operations
+- Use `tapResponse` for error handling
+- Use `patchState` for state updates
+- Explicit return types on all computed signals

--- a/.github/skills/frontend-test/SKILL.md
+++ b/.github/skills/frontend-test/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: frontend-test
+description: >
+  Vitest and Playwright test patterns for Chairly frontend.
+  Use when writing unit tests for components or e2e tests for features.
+---
+
+# Frontend Test Patterns
+
+## Vitest — Component unit test
+
+Location: `libs/chairly/src/lib/{domain}/ui/{component-name}/{component-name}.component.spec.ts`
+
+```typescript
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { {ComponentName}Component } from './{component-name}.component';
+
+describe('{ComponentName}Component', () => {
+  let component: {ComponentName}Component;
+  let fixture: ComponentFixture<{ComponentName}Component>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [{ComponentName}Component],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent({ComponentName}Component);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});
+```
+
+## Playwright — E2E test
+
+Location: `apps/chairly-e2e/src/{domain}.spec.ts`
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('{Domain} page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/{domain}');
+  });
+
+  test('should display the page title', async ({ page }) => {
+    // All assertions against Dutch text
+    await expect(page.getByRole('heading', { name: '{Dutch title}' })).toBeVisible();
+  });
+
+  test('should load items', async ({ page }) => {
+    await expect(page.getByRole('table')).toBeVisible();
+  });
+});
+```
+
+## Rules
+
+- All e2e test assertions use Dutch UI text
+- Use `page.keyboard.press('Escape')` to close `showModal()` dialogs (cross-browser reliable)
+- E2E tests go in `apps/chairly-e2e/src/`
+- Unit tests go alongside the component file
+- Test naming: `should {expected behavior}`
+
+## Running tests
+
+```bash
+# Unit tests
+cd src/frontend/chairly
+npx nx affected -t test --base=main
+
+# E2E tests
+npx nx affected -t e2e --base=main
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# Chairly — Agent Instructions
+
+You are working on the Chairly multi-tenant SaaS platform for salons and barbershops.
+
+## Workflow
+
+This project uses a structured agentic workflow with specialized agents. Follow these phases when implementing features end-to-end:
+
+### Phase 1 — Specification
+
+Use the `spec-writer` agent interactively to create a feature spec. The spec is written to `.github/tasks/{feature-name}/spec.md` with YAML frontmatter for task tracking and Markdown body for human review.
+
+### Phase 2 — Implementation
+
+Use `/fleet` to parallelize work across the `backend-dev` and `frontend-dev` agents:
+
+```
+/fleet Implement the feature spec at .github/tasks/{feature-name}/spec.md.
+Use the backend-dev agent for all backend tasks and the frontend-dev agent for all frontend tasks.
+Set up git worktrees for isolation:
+  - .worktrees/{feature-name}/backend/ on branch impl/{feature-name}-backend
+  - .worktrees/{feature-name}/frontend/ on branch impl/{feature-name}-frontend
+Both branch from feat/{feature-name}.
+```
+
+### Phase 3 — Review
+
+Use the `reviewer` agent to review the implementation. It auto-fixes what it can and writes remaining findings to `.github/tasks/{feature-name}/review.md`.
+
+### Phase 4 — Pull Request
+
+After review, merge worktree branches into the feature branch and create a PR:
+
+```bash
+git checkout feat/{feature-name}
+git merge --no-ff impl/{feature-name}-backend -m "chore: merge backend implementation"
+git merge --no-ff impl/{feature-name}-frontend -m "chore: merge frontend implementation"
+git push -u origin feat/{feature-name}
+gh pr create --title "feat({context}): {description}" --body "See .github/tasks/{feature-name}/spec.md"
+```
+
+### Phase 5 — Rework
+
+After PR review, use the `rework` agent to fix review comments:
+
+```
+copilot --agent=rework --prompt "fix PR #{number} comments"
+```
+
+## Git Branching
+
+```
+main
+ └── feat/{feature-name}           ← PR target
+      ├── impl/{feature-name}-backend    ← worktree
+      └── impl/{feature-name}-frontend   ← worktree
+```
+
+## Key References
+
+- Domain model: `docs/domain-model.md`
+- Architecture decisions: `docs/adr/`
+- Feature specs: `.github/tasks/{feature-name}/spec.md`
+- Project conventions: `.github/copilot-instructions.md`
+- Backend patterns: `.github/instructions/backend.instructions.md`
+- Frontend patterns: `.github/instructions/frontend.instructions.md`
+
+## Autonomous Mode
+
+When running in autopilot (`--autopilot --yolo`):
+- Do NOT stop to ask questions — make decisions based on existing patterns, ADRs, and specs
+- Follow conventions established in the codebase
+- When in doubt, choose the simplest approach that follows existing patterns
+- Always run quality checks before committing
+- Use conventional commits: `feat(context): description`

--- a/scripts/copilot/pre-commit-check.sh
+++ b/scripts/copilot/pre-commit-check.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Pre-commit quality gate for Copilot CLI hooks.
+# This hook runs on preToolUse. It checks if the tool being used is a git commit,
+# and if so, runs the appropriate quality checks based on changed files.
+#
+# Environment variables set by Copilot:
+#   COPILOT_TOOL_NAME — the tool being invoked (e.g., "shell")
+#   COPILOT_TOOL_INPUT — the tool input (e.g., the shell command)
+
+set -euo pipefail
+
+# Only gate git commit commands
+if [[ "${COPILOT_TOOL_NAME:-}" != "shell" ]]; then
+  exit 0
+fi
+
+if ! echo "${COPILOT_TOOL_INPUT:-}" | grep -q "git commit"; then
+  exit 0
+fi
+
+echo "Pre-commit quality gate: checking changed files..."
+
+# Determine what changed
+BACKEND_CHANGED=false
+FRONTEND_CHANGED=false
+
+if git diff --cached --name-only | grep -q "^src/backend/"; then
+  BACKEND_CHANGED=true
+fi
+
+if git diff --cached --name-only | grep -q "^src/frontend/"; then
+  FRONTEND_CHANGED=true
+fi
+
+EXIT_CODE=0
+
+if [[ "$BACKEND_CHANGED" == "true" ]]; then
+  echo "Backend changes detected. Running quality checks..."
+  if ! dotnet build src/backend/Chairly.slnx; then
+    echo "FAIL: dotnet build failed"
+    EXIT_CODE=1
+  fi
+  if ! dotnet test src/backend/Chairly.slnx; then
+    echo "FAIL: dotnet test failed"
+    EXIT_CODE=1
+  fi
+  if ! dotnet format src/backend/Chairly.slnx --verify-no-changes; then
+    echo "FAIL: dotnet format check failed. Run 'dotnet format src/backend/Chairly.slnx' to fix."
+    EXIT_CODE=1
+  fi
+fi
+
+if [[ "$FRONTEND_CHANGED" == "true" ]]; then
+  echo "Frontend changes detected. Running quality checks..."
+  cd src/frontend/chairly
+  if ! npx nx affected -t lint --base=main; then
+    echo "FAIL: nx lint failed"
+    EXIT_CODE=1
+  fi
+  if ! npx nx format:check --base=main; then
+    echo "FAIL: nx format:check failed. Run 'npx nx format --base=main' to fix."
+    EXIT_CODE=1
+  fi
+  if ! npx nx affected -t test --base=main; then
+    echo "FAIL: nx test failed"
+    EXIT_CODE=1
+  fi
+  if ! npx nx affected -t build --base=main; then
+    echo "FAIL: nx build failed"
+    EXIT_CODE=1
+  fi
+  cd ../../..
+fi
+
+if [[ "$EXIT_CODE" -ne 0 ]]; then
+  echo "Quality gate FAILED. Fix the issues above before committing."
+  exit 1
+fi
+
+echo "Quality gate passed."
+exit 0


### PR DESCRIPTION
## Summary

- Adds a complete GitHub Copilot CLI agentic workflow with instructions, agents, skills, hooks, and documentation
- Enables spec creation (interactive, from GitHub issues, or file), autonomous implementation with `/fleet` parallelization, code review with auto-fix, PR creation, and rework based on PR comments
- Fully separate from the existing Claude Code / Ralph workflow to allow side-by-side evaluation

## What's included

**Instructions (5 files)** — modular, scoped by `applyTo` glob patterns:
- `copilot-instructions.md` (always loaded), `backend.instructions.md`, `frontend.instructions.md`, `testing.instructions.md`, `workflow.instructions.md`

**Agents (5 files)** — role-based `.agent.md` subagents:
- `spec-writer`, `backend-dev`, `frontend-dev`, `reviewer`, `rework`

**Skills (10 files)** — fine-grained pattern libraries loaded on demand:
- Backend: `entity`, `handler`, `endpoint`, `ef-config`, `test`
- Frontend: `store`, `service`, `component`, `routing`, `test`

**Hooks** — pre-commit quality gate that runs build/test/lint per layer

**Documentation** — full workflow README at `.github/docs/copilot-workflow.md`

## Test plan

- [ ] Install Copilot CLI and verify `copilot --agent=spec-writer` loads the agent
- [ ] Verify `/skills list` shows all 10 skills
- [ ] Test spec creation from a GitHub issue: `copilot --agent=spec-writer --prompt "Create a spec from issue #1"`
- [ ] Test autopilot implementation flow with a small feature
- [ ] Verify pre-commit hook blocks commits when quality checks fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)