### PR TITLE
fix(startup): throw meaningful error when connection strings are missing

### DIFF
--- a/src/backend/Chairly.Api/Program.cs
+++ b/src/backend/Chairly.Api/Program.cs
@@ -189,7 +189,8 @@ if (runMigrations)
     //    EF Core to correctly bootstrap __EFMigrationsHistory on a fresh database.
     // 3. If the process crashes, the non-pooled connection is closed by the OS,
     //    releasing the lock immediately — no stale locks in the connection pool.
-    var connString = app.Configuration.GetConnectionString("ChairlyDb")!;
+    var connString = app.Configuration.GetConnectionString("ChairlyDb")
+        ?? throw new InvalidOperationException("Connection string 'ChairlyDb' is not configured.");
 
     // Append Pooling=false so this connection is truly closed on dispose, not
     // returned to Npgsql's pool where a session-level advisory lock would persist.
@@ -265,7 +266,8 @@ if (runMigrations)
     var websiteMigrationLogger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger("Chairly.WebsiteMigrations");
     var websiteStoppingToken = app.Lifetime.ApplicationStopping;
 
-    var websiteConnString = app.Configuration.GetConnectionString("WebsiteDb")!;
+    var websiteConnString = app.Configuration.GetConnectionString("WebsiteDb")
+        ?? throw new InvalidOperationException("Connection string 'WebsiteDb' is not configured.");
 
     var websiteLockConnString = websiteConnString.Contains("Pooling=", StringComparison.OrdinalIgnoreCase)
         ? websiteConnString


### PR DESCRIPTION
## Bug Fix

**Bug:** Application crashes on startup with `NullReferenceException` at `Program.cs:196`

**Root cause:** `GetConnectionString("ChairlyDb")` returns `null` when the connection string is not configured (e.g. running outside Aspire). The `!` null-forgiving operator suppressed the compiler warning but not the runtime crash — `connString.Contains(...)` then threw `NullReferenceException`. Same issue existed for `WebsiteDb`.

## Changes

- `Program.cs`: replaced `!` null-forgiving operator with `?? throw new InvalidOperationException(...)` for both `ChairlyDb` and `WebsiteDb` connection strings

## Quality gates

- `dotnet build` — passed (0 warnings, 0 errors)